### PR TITLE
bugfix: Avoid expression '0 - _' when computing iid_acc

### DIFF
--- a/src/circuits/etable_compact/mod.rs
+++ b/src/circuits/etable_compact/mod.rs
@@ -464,7 +464,8 @@ impl<F: FieldExt> EventTableConfig<F> {
                 common_config.input_index(meta) - common_config.next_input_index(meta);
             let mut moid_acc = common_config.next_moid(meta) - common_config.moid(meta);
             let mut fid_acc = common_config.next_fid(meta) - common_config.fid(meta);
-            let mut iid_acc = common_config.next_iid(meta) - common_config.iid(meta);
+            let mut iid_acc =
+                common_config.next_iid(meta) - common_config.iid(meta) - constant_from!(1);
             let mut sp_acc = common_config.next_sp(meta) - common_config.sp(meta);
             let mut last_jump_eid_acc =
                 common_config.next_last_jump_eid(meta) - common_config.last_jump_eid(meta);
@@ -531,7 +532,7 @@ impl<F: FieldExt> EventTableConfig<F> {
                 match config.next_iid(meta, &common_config) {
                     Some(e) => {
                         iid_acc = iid_acc
-                            - (e - common_config.iid(meta))
+                            + (constant_from!(1) + common_config.iid(meta) - e)
                                 * common_config.op_enabled(meta, *lvl1, *lvl2)
                     }
                     _ => {}

--- a/src/circuits/etable_compact/op_configure/mod.rs
+++ b/src/circuits/etable_compact/op_configure/mod.rs
@@ -594,10 +594,10 @@ pub trait EventTableOpcodeConfig<F: FieldExt> {
     }
     fn next_iid(
         &self,
-        meta: &mut VirtualCells<'_, F>,
-        common_config: &EventTableCommonConfig<F>,
+        _meta: &mut VirtualCells<'_, F>,
+        _common_config: &EventTableCommonConfig<F>,
     ) -> Option<Expression<F>> {
-        Some(common_config.iid(meta) + constant_from!(1))
+        None
     }
     fn mtable_lookup(
         &self,


### PR DESCRIPTION
The expression '0 - _' appears to be likely to trigger a halo2 bug that results in verify_check failing.
However I don't known the reason.

Someone can reproduce the bug by reverting this commit and setting the commit in wasmi to
43c8b071bc1170d67143e00d8a4dfe8d4803e788