### PR TITLE
BUGFIX: fix size of public inputs

### DIFF
--- a/ctest/allprivate.c
+++ b/ctest/allprivate.c
@@ -1,8 +1,0 @@
-#include <stdint.h>
-unsigned long long wasm_input(int);
-__attribute__((visibility("default")))
-int zkmain() {
-    uint32_t a = (uint32_t)wasm_input(0);
-    uint32_t b = (uint32_t)wasm_input(0);
-    return a+b;
-}

--- a/ctest/arith.c
+++ b/ctest/arith.c
@@ -1,14 +1,11 @@
 #include <stdint.h>
-void assert(int cond)
-{
-    if (!cond) __builtin_unreachable();
-}
+void require(int cond);
 
 unsigned long long wasm_input(int);
 __attribute__((visibility("default")))
 int zkmain() {
     uint32_t a = (uint32_t)wasm_input(1);
     uint32_t b = (uint32_t)wasm_input(1);
-    assert(a > b);
+    require(a > b);
     return a + b;
 }

--- a/ctest/arith.c
+++ b/ctest/arith.c
@@ -1,8 +1,14 @@
 #include <stdint.h>
+void assert(int cond)
+{
+    if (!cond) __builtin_unreachable();
+}
+
 unsigned long long wasm_input(int);
 __attribute__((visibility("default")))
 int zkmain() {
     uint32_t a = (uint32_t)wasm_input(1);
     uint32_t b = (uint32_t)wasm_input(1);
-    return a+b;
+    assert(a > b);
+    return a + b;
 }

--- a/ctest/batchinput.c
+++ b/ctest/batchinput.c
@@ -1,11 +1,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #if defined(__wasm__)
-
-void assert(int cond)
-{
-    if (!cond) __builtin_unreachable();
-}
+void require(int cond);
 #endif
 
 unsigned long long wasm_input(int);
@@ -20,7 +16,7 @@ static __inline__ void read_bytes_from_u64(void *dst, int byte_length, bool is_p
         } else {
             //less then 16 bytes on demand
             uint64_t uint64_cache = wasm_input(is_public);
-            uint8_t *u8_p = (uint8_t *)uint64_cache;
+            uint8_t *u8_p = (uint8_t *)(&uint64_cache);
             #pragma clang loop unroll(full)
             for (int j = i*8; j<byte_length; j++) {
               ((uint8_t *)dst)[j] = u8_p[j-i*8];
@@ -33,6 +29,6 @@ __attribute__((visibility("default")))
 int zkmain() {
     uint8_t bytes[8];
     read_bytes_from_u64(bytes, 8, 0);
-    assert(bytes[7] == 1);
+    require(bytes[7] == 1);
     return 0;
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -52,7 +52,7 @@ struct SampleApp;
 
 impl ArgBuilder for SampleApp {
     fn single_public_arg<'a>() -> Arg<'a> {
-        arg!(--public [PUBLIC_INPUT] "Public arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed, multiple values should be separated with ','")
+        arg!(--public <PUBLIC_INPUT>... "Public arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed, multiple values should be separated with ','")
             .use_value_delimiter(true)
             .min_values(0)
             .value_parser(value_parser!(String))
@@ -78,7 +78,7 @@ impl ArgBuilder for SampleApp {
     }
 
     fn single_private_arg<'a>() -> Arg<'a> {
-        arg!(--private [PRIVATE_INPUT] "Private arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed, multiple values should be separated with ','")
+        arg!(--private <PRIVATE_INPUT>... "Private arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed, multiple values should be separated with ','")
             .use_value_delimiter(true)
             .min_values(0)
             .value_parser(value_parser!(String))
@@ -110,7 +110,7 @@ impl AppBuilder for SampleApp {
 
     const ZKWASM_K: u32 = 18;
     const AGGREGATE_K: u32 = 23;
-    const MAX_PUBLIC_INPUT_SIZE: usize = 1;
+    const MAX_PUBLIC_INPUT_SIZE: usize = 64;
 
     const N_PROOFS: usize = 1;
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,4 +1,4 @@
-use clap::{arg, value_parser, Arg, ArgMatches};
+use clap::{value_parser, Arg, ArgMatches, ArgAction};
 use delphinus_zkwasm::cli::{app_builder::AppBuilder, args::ArgBuilder, command::CommandBuilder};
 
 fn parse_args(values: Vec<&str>) -> Vec<u64> {
@@ -52,10 +52,12 @@ struct SampleApp;
 
 impl ArgBuilder for SampleApp {
     fn single_public_arg<'a>() -> Arg<'a> {
-        arg!(--public <PUBLIC_INPUT>... "Public arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed, multiple values should be separated with ','")
-            .use_value_delimiter(true)
-            .min_values(0)
+        Arg::new("public")
+            .long("public")
             .value_parser(value_parser!(String))
+            .action(ArgAction::Append)
+            .help("Public arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed")
+            .min_values(0)
     }
     fn parse_single_public_arg(matches: &ArgMatches) -> Vec<u64> {
         let inputs: Vec<&str> = matches
@@ -78,10 +80,12 @@ impl ArgBuilder for SampleApp {
     }
 
     fn single_private_arg<'a>() -> Arg<'a> {
-        arg!(--private <PRIVATE_INPUT>... "Private arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed, multiple values should be separated with ','")
-            .use_value_delimiter(true)
-            .min_values(0)
+        Arg::new("private")
+            .long("private")
             .value_parser(value_parser!(String))
+            .action(ArgAction::Append)
+            .help("Private arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed")
+            .min_values(0)
     }
     fn parse_single_private_arg(matches: &ArgMatches) -> Vec<u64> {
         let inputs: Vec<&str> = matches


### PR DESCRIPTION
1. Set the default MAX SIZE of public input to 64.
2. Allow multiple values for public and private inputs.