### PR TITLE
fix: correct cli argument separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ with OPTIONS:
 
         --private [<PRIVATE_INPUT>...]
             Private arguments of your wasm program arguments of format value:type where
-            type=i64|bytes|bytes-packed, multiple values should be separated with ','
+            type=i64|bytes|bytes-packed, multiple values should be separated with ' ' (space)
 
         --public [<PUBLIC_INPUT>...]
             Public arguments of your wasm program arguments of format value:type where
-            type=i64|bytes|bytes-packed, multiple values should be separated with ','
+            type=i64|bytes|bytes-packed, multiple values should be separated with ' ' (space)
 ```
 ## Batch prove and verify:
 ```


### PR DESCRIPTION
When using cli to pass in inputs in OPTIONS of prove and verify, the separator should be ' ' (space).

If use ',' (comma) as separator as the doc suggested, the following error will be outputted.

```bash
RUST_BACKTRACE=1 RUST_LOG=info cargo run --release --features cuda -- -k 18 --function zkmain --output ./output --wasm wasm/a.wasm single-prove --private 0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1:bytes-packed,0x0000000000000000000000000000000000000000000000000000000000000000:bytes-packed,0x0000000000000000000000000000000000000000000000000000000000000000:bytes-packed,0x0000000000000000000000000000000000000000000000000000000000000000:bytes-packed,0x40:i64,0x00000000000000000000000000000000000000000014df54140456547ac7f6570000000000000000000000000000000000000000000000040f915afbed20232c:bytes-packed,0x20:i64,0x0000000000000000000000000000000000000000000000000000000000000001:bytes-packed

    Finished release [optimized] target(s) in 0.08s
     Running `target/release/cli -k 18 --function zkmain --output ./output --wasm wasm/a.wasm single-prove --private '0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1:bytes-packed,0x0000000000000000000000000000000000000000000000000000000000000000:bytes-packed,0x0000000000000000000000000000000000000000000000000000000000000000:bytes-packed,0x0000000000000000000000000000000000000000000000000000000000000000:bytes-packed,0x40:i64,0x00000000000000000000000000000000000000000014df54140456547ac7f6570000000000000000000000000000000000000000000000040f915afbed20232c:bytes-packed,0x20:i64,0x0000000000000000000000000000000000000000000000000000000000000001:bytes-packed'`
thread 'main' panicked at 'not yet implemented', src/cli/main.rs:13:73
stack backtrace:
   0: rust_begin_unwind
             at /rustc/ff8c8dfbe66701531e3e5e335c28c544d0fbc945/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/ff8c8dfbe66701531e3e5e335c28c544d0fbc945/library/core/src/panicking.rs:65:14
   2: core::panicking::panic
             at /rustc/ff8c8dfbe66701531e3e5e335c28c544d0fbc945/library/core/src/panicking.rs:114:5
   3: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
   4: <core::iter::adapters::flatten::Flatten<I> as core::iter::traits::iterator::Iterator>::next
   5: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
   6: <cli::SampleApp as delphinus_zkwasm::cli::args::ArgBuilder>::parse_single_private_arg
   7: cli::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```