### PR TITLE
feat: Update halo2_proofs rev to reduce memory cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.1.0-beta.1"
-source = "git+https://github.com/junyu0312/halo2?branch=gpu#34d9c91e79deb055589964bec13624f0fb11dfb4"
+source = "git+https://github.com/junyu0312/halo2?branch=gpu#7b0b5190c2fc5c510bbbcfc54a6ccbe1bceb6619"
 dependencies = [
  "ark-std",
  "blake2b_simd",


### PR DESCRIPTION
For k=18 non-checksum version, it requires memory size less than 8GB.