### PR TITLE
update to bisect-lookup-0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.1.0-beta.1"
-source = "git+https://github.com/junyu0312/halo2?branch=gpu#7b0b5190c2fc5c510bbbcfc54a6ccbe1bceb6619"
+source = "git+https://github.com/junyu0312/halo2?branch=gpu#d641021e6813de5314469862c6c4be08d4a639fd"
 dependencies = [
  "ark-std",
  "blake2b_simd",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "halo2aggregator-s"
 version = "0.1.0"
-source = "git+https://github.com/DelphinusLab/halo2aggregator-s.git?tag=bisect-lookup-0.2.1#2db58881aecff8f5a9c95ce9a8e1c023c92a9ce7"
+source = "git+https://github.com/DelphinusLab/halo2aggregator-s.git?tag=bisect-lookup-0.3.0#fa6e8033d960c1e13ac334ab5699f64c80fe47ab"
 dependencies = [
  "ark-std",
  "blake2b_simd",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "halo2ecc-s"
 version = "0.2.0"
-source = "git+https://github.com/lanbones/halo2ecc-s.git?tag=bisect-lookup-0.2.1#11059fc86b1d9773a6ffca1a44b119c9f0841ded"
+source = "git+https://github.com/lanbones/halo2ecc-s.git?tag=bisect-lookup-0.3.0#99d0a2abe633651a997cf5bf0e0e2bf70f624347"
 dependencies = [
  "halo2_proofs",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.68"
 ark-std = { version = "0.3.0", features = ["print-trace"] }
 downcast-rs = "1.2.0"
 env_logger = "0.9.3"
-halo2aggregator-s = { git = "https://github.com/DelphinusLab/halo2aggregator-s.git", tag = "bisect-lookup-0.2.1" }
+halo2aggregator-s = { git = "https://github.com/DelphinusLab/halo2aggregator-s.git", tag = "bisect-lookup-0.3.0", features = ["unsafe"] }
 halo2_proofs = { git = "https://github.com/junyu0312/halo2", branch = "gpu", default-features = true }
 log = "0.4.17"
 md5 = "0.7.0"

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -122,7 +122,12 @@ impl AppBuilder for SampleApp {
     const NAME: &'static str = "zkwasm";
     const VERSION: &'static str = "v1.0-beta";
 
+    #[cfg(feature = "checksum")]
     const AGGREGATE_K: u32 = 22;
+
+    #[cfg(not(feature = "checksum"))]
+    const AGGREGATE_K: u32 = 21;
+
     const MAX_PUBLIC_INPUT_SIZE: usize = 64;
 
     const N_PROOFS: usize = 1;


### PR DESCRIPTION
The halo2ecc-s on bisect-lookup-0.3.0 supports unsafe ecc ops, which can reduce circuit size.