### PR TITLE
Private inputs

### DIFF
--- a/crates/cli/src/app_builder.rs
+++ b/crates/cli/src/app_builder.rs
@@ -115,8 +115,8 @@ pub trait AppBuilder: CommandBuilder {
             }
             Some(("dry-run", sub_matches)) => {
                 let public_inputs: Vec<u64> = Self::parse_single_public_arg(&sub_matches);
-                let private_inputs: Vec<u64> = match sub_matches.contains_id("preimages") {
-                    true => Self::parse_preimage(&sub_matches),
+                let private_inputs: Vec<u64> = match sub_matches.contains_id("private_file") {
+                    true => Self::parse_private_file(&sub_matches),
                     false => Self::parse_single_private_arg(&sub_matches)
                 };
                 let context_in: Vec<u64> = Self::parse_context_in_arg(&sub_matches);

--- a/crates/cli/src/app_builder.rs
+++ b/crates/cli/src/app_builder.rs
@@ -115,7 +115,10 @@ pub trait AppBuilder: CommandBuilder {
             }
             Some(("dry-run", sub_matches)) => {
                 let public_inputs: Vec<u64> = Self::parse_single_public_arg(&sub_matches);
-                let private_inputs: Vec<u64> = Self::parse_single_private_arg(&sub_matches);
+                let private_inputs: Vec<u64> = match sub_matches.contains_id("preimages") {
+                    true => Self::parse_preimage(&sub_matches),
+                    false => Self::parse_single_private_arg(&sub_matches)
+                };
                 let context_in: Vec<u64> = Self::parse_context_in_arg(&sub_matches);
                 let context_out_path: Option<PathBuf> =
                     Self::parse_context_out_path_arg(&sub_matches);

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -59,7 +59,7 @@ pub fn parse_args(values: Vec<&str>) -> Vec<u64> {
         .collect()
 }
 
-pub fn parse_image_files(filepath:String) -> Vec<u64> {
+pub fn parse_binary(filepath:String) -> Vec<u64> {
     let bytes = fs::read(filepath).unwrap();
     let bytes = bytes.chunks(8);
     let data = bytes
@@ -176,14 +176,13 @@ pub trait ArgBuilder {
     fn single_private_arg<'a>() -> Arg<'a>;
     fn parse_single_private_arg(matches: &ArgMatches) -> Vec<u64>;
 
-    fn preimage_arg<'a>() -> Arg<'a>;
-    fn parse_preimage(matches: &ArgMatches) -> Vec<u64>{
+    fn private_file_arg<'a>() -> Arg<'a>;
+    fn parse_private_file(matches: &ArgMatches) -> Vec<u64>{
         let filepath = matches
-            .get_one::<String>("preimages")
-            .expect("preimages is required")
+            .get_one::<String>("private_file")
+            .expect("private_file is required")
             .to_string();     
-        println!("prv file path===>{:?}", filepath);
-        parse_image_files(filepath)
+        parse_binary(filepath)
     }
 
     fn aggregate_private_args<'a>() -> Arg<'a>;

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -5,6 +5,7 @@ use clap::value_parser;
 use clap::Arg;
 use clap::ArgAction;
 use clap::ArgMatches;
+use std::fs;
 
 pub fn parse_args(values: Vec<&str>) -> Vec<u64> {
     values
@@ -57,6 +58,21 @@ pub fn parse_args(values: Vec<&str>) -> Vec<u64> {
         .flatten()
         .collect()
 }
+
+pub fn parse_image_files(filepath:String) -> Vec<u64> {
+    let bytes = fs::read(filepath).unwrap();
+    let bytes = bytes.chunks(8);
+    let data = bytes
+        .into_iter()
+        .map(|x| {
+            let mut data = [0u8; 8];
+            data[..x.len()].copy_from_slice(x);
+
+            u64::from_be_bytes(data)
+        })
+        .collect::<Vec<u64>>();
+    data
+} 
 
 pub trait ArgBuilder {
     fn zkwasm_k_arg<'a>() -> Arg<'a> {
@@ -159,6 +175,16 @@ pub trait ArgBuilder {
 
     fn single_private_arg<'a>() -> Arg<'a>;
     fn parse_single_private_arg(matches: &ArgMatches) -> Vec<u64>;
+
+    fn preimage_arg<'a>() -> Arg<'a>;
+    fn parse_preimage(matches: &ArgMatches) -> Vec<u64>{
+        let filepath = matches
+            .get_one::<String>("preimages")
+            .expect("preimages is required")
+            .to_string();     
+        println!("prv file path===>{:?}", filepath);
+        parse_image_files(filepath)
+    }
 
     fn aggregate_private_args<'a>() -> Arg<'a>;
     fn parse_aggregate_private_args(matches: &ArgMatches) -> Vec<Vec<u64>>;

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -23,7 +23,7 @@ pub trait CommandBuilder: ArgBuilder {
             .arg(Self::dry_run_service_arg())
             .arg(Self::context_in_arg())
             .arg(Self::context_out_path_arg())
-            .arg(Self::preimage_arg());
+            .arg(Self::private_file_arg());
 
         app.subcommand(command)
     }

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -22,7 +22,8 @@ pub trait CommandBuilder: ArgBuilder {
             .arg(Self::single_private_arg())
             .arg(Self::dry_run_service_arg())
             .arg(Self::context_in_arg())
-            .arg(Self::context_out_path_arg());
+            .arg(Self::context_out_path_arg())
+            .arg(Self::preimage_arg());
 
         app.subcommand(command)
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,6 +44,15 @@ impl ArgBuilder for SampleApp {
         vec![inputs]
     }
 
+    fn preimage_arg<'a>() -> Arg<'a> {
+        Arg::new("preimages")
+            .long("preimages")
+            .value_parser(value_parser!(String))
+            .action(ArgAction::Append)
+            .help("Private arguments of your wasm program arguments of filepath")
+            .min_values(0)
+    }
+
     fn single_private_arg<'a>() -> Arg<'a> {
         Arg::new("private")
             .long("private")
@@ -86,7 +95,11 @@ impl AppBuilder for SampleApp {
 
 /// Simple program to greet a person
 fn main() -> Result<()> {
+    use std::time::SystemTime;
+    let sy_time = SystemTime::now();
     let app = SampleApp::app_builder();
 
-    SampleApp::exec(app)
+    SampleApp::exec(app);
+    println!("Time elapsed:{:?}s", sy_time.elapsed().unwrap().as_secs());
+    Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,12 +44,12 @@ impl ArgBuilder for SampleApp {
         vec![inputs]
     }
 
-    fn preimage_arg<'a>() -> Arg<'a> {
-        Arg::new("preimages")
-            .long("preimages")
+    fn private_file_arg<'a>() -> Arg<'a> {
+        Arg::new("private_file")
+            .long("private_file")
             .value_parser(value_parser!(String))
             .action(ArgAction::Append)
-            .help("Private arguments of your wasm program arguments of filepath")
+            .help("Filepath for private arguments of your wasm program arguments of binary format")
             .min_values(0)
     }
 
@@ -95,11 +95,7 @@ impl AppBuilder for SampleApp {
 
 /// Simple program to greet a person
 fn main() -> Result<()> {
-    use std::time::SystemTime;
-    let sy_time = SystemTime::now();
     let app = SampleApp::app_builder();
-
     SampleApp::exec(app);
-    println!("Time elapsed:{:?}s", sy_time.elapsed().unwrap().as_secs());
     Ok(())
 }

--- a/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
+++ b/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
@@ -82,8 +82,7 @@ pub fn register_wasm_input_foreign(
                 context.push_public(value);
                 value
             } else {
-                let value = context.pop_private();
-                value
+                context.pop_private()
             };
 
             Some(wasmi::RuntimeValue::I64(input as i64))
@@ -96,7 +95,6 @@ pub fn register_wasm_input_foreign(
 
             let value: i64 = args.nth(0);
             context.push_output(value as u64);
-            println!("wasm_output:{:?}",value);
             None
         },
     );

--- a/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
+++ b/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
@@ -82,7 +82,8 @@ pub fn register_wasm_input_foreign(
                 context.push_public(value);
                 value
             } else {
-                context.pop_private()
+                let value = context.pop_private();
+                value
             };
 
             Some(wasmi::RuntimeValue::I64(input as i64))
@@ -95,7 +96,7 @@ pub fn register_wasm_input_foreign(
 
             let value: i64 = args.nth(0);
             context.push_output(value as u64);
-
+            println!("wasm_output:{:?}",value);
             None
         },
     );

--- a/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
+++ b/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
@@ -33,10 +33,16 @@ impl Context {
     }
 
     pub fn pop_public(&mut self) -> u64 {
+        if self.public_inputs.is_empty() {
+            panic!("failed to read public input, please checkout your input");
+        }
         self.public_inputs.remove(0)
     }
 
     pub fn pop_private(&mut self) -> u64 {
+        if self.private_inputs.is_empty() {
+            panic!("failed to read private input, please checkout your input");
+        }
         self.private_inputs.remove(0)
     }
 


### PR DESCRIPTION
When the private inputs are large, we suggest using binary files as private inputs. The format is also binary, so we don't need to encode it to string and then decode it.