### PR TITLE
change compile to pub

### DIFF
--- a/crates/zkwasm/src/loader/mod.rs
+++ b/crates/zkwasm/src/loader/mod.rs
@@ -96,7 +96,7 @@ impl<E: MultiMillerLoop> ZkWasmLoader<E> {
         Ok(())
     }
 
-    fn compile(&self, env: &HostEnv) -> Result<CompiledImage<NotStartedModuleRef<'_>, Tracer>> {
+    pub fn compile(&self, env: &HostEnv) -> Result<CompiledImage<NotStartedModuleRef<'_>, Tracer>> {
         let imports = ImportsBuilder::new().with_resolver("env", env);
 
         WasmInterpreter::compile(


### PR DESCRIPTION
We need pre-do compile in a spawn thread to avoid the wasmi panic to crash the calling serivce.
The other pub function like checksum() which use it will need big param which normally have to be in a mutex cache so the panic will poison the mutex/lock and make cache never be using anymore

https://delphinuslab.atlassian.net/browse/ZKWAS-147