### PR TITLE
reset keccak256 cursor in keccak_new()

### DIFF
--- a/crates/host/src/host/hash_helper/keccak256.rs
+++ b/crates/host/src/host/hash_helper/keccak256.rs
@@ -48,6 +48,7 @@ impl Keccak256Context {
 
     pub fn keccak_new(&mut self, new: usize) {
         self.buf = vec![];
+        self.generator.cursor = 0;
         if new != 0 {
             self.hasher = Some(KECCAK_HASHER.clone());
             self.used_round += 1;


### PR DESCRIPTION
After calling absorbing 136 bytes by calling keccak_finalize(), the cursor should be reset in next keccak_new() call.  Otherwise, calling keccak_finalize() to absorb the following bytes will crash cli with the error:

thread 'main' panicked at 'index out of bounds: the len is 4 but the index is 4', crates/host/src/host/hash_helper/keccak256.rs:18:17