### PR TITLE
feat: add --private filename:file

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ with OPTIONS:
         The md5 of the wasm binary file is the default path if not supplied.
 
     --private [<PRIVATE_INPUT>...]
-        Private arguments of your wasm program arguments of format value:type where
-        type=i64|bytes|bytes-packed, multiple values should be separated with ' ' (space)
+        Private arguments of your wasm program arguments of format value/filename:type where
+        type=i64|bytes|bytes-packed|file, multiple values should be separated with ' ' (space); file should be encoded with binary BigEndian bytes order
 
     --public [<PUBLIC_INPUT>...]
         Public arguments of your wasm program arguments of format value:type where

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -49,7 +49,7 @@ impl ArgBuilder for SampleApp {
             .long("private")
             .value_parser(value_parser!(String))
             .action(ArgAction::Append)
-            .help("Private arguments of your wasm program arguments of format value:type where type=i64|bytes|bytes-packed")
+            .help("Private arguments of your wasm program arguments of format value/filename:type where type=i64|bytes|bytes-packed|file")
             .min_values(0)
     }
     fn parse_single_private_arg(matches: &ArgMatches) -> Vec<u64> {

--- a/crates/specs/src/args.rs
+++ b/crates/specs/src/args.rs
@@ -39,11 +39,24 @@ pub fn parse_args(values: Vec<&str>) -> Vec<u64> {
                             u64::from_le_bytes(data)
                         })
                         .collect::<Vec<u64>>()
-                }
+                },
+                "file" => {
+                    let bytes = std::fs::read(v).unwrap();
+                    let bytes = bytes.chunks(8);
+                    bytes
+                        .into_iter()
+                        .map(|x| {
+                            let mut data = [0u8; 8];
+                            data[..x.len()].copy_from_slice(x);
 
+                            u64::from_be_bytes(data)
+                        })
+                        .collect()
+                },
                 _ => {
                     panic!("Unsupported input data type: {}", t)
-                }
+                },
+
             }
         })
         .flatten()

--- a/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
+++ b/crates/zkwasm/src/foreign/wasm_input_helper/runtime.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::rc::Rc;
 
 use specs::host_function::HostPlugin;
@@ -12,7 +13,7 @@ use super::Op;
 
 pub struct Context {
     pub public_inputs: Vec<u64>,
-    pub private_inputs: Vec<u64>,
+    pub private_inputs: VecDeque<u64>,
     pub instance: Rc<RefCell<Vec<u64>>>,
     pub output: Rc<RefCell<Vec<u64>>>,
 }
@@ -26,7 +27,7 @@ impl Context {
     ) -> Self {
         Context {
             public_inputs,
-            private_inputs,
+            private_inputs: private_inputs.into(),
             instance,
             output,
         }
@@ -43,7 +44,7 @@ impl Context {
         if self.private_inputs.is_empty() {
             panic!("failed to read private input, please checkout your input");
         }
-        self.private_inputs.remove(0)
+        self.private_inputs.pop_front().unwrap()
     }
 
     fn push_public(&mut self, value: u64) {


### PR DESCRIPTION
1. The new filetype is compatible with current cli params
2. Change `private_files` to `VecDeque` to make it more efficient when popping the first item, compare to the original `self.private_inputs.remove(0)`