### PR TITLE
fix: fix "entries" typo

### DIFF
--- a/crates/zkwasm/src/circuits/etable/op_configure/op_bin.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_bin.rs
@@ -554,9 +554,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinConfig<F> {
 
         self.memory_table_lookup_stack_read_rhs.assign(
             ctx,
-            entry.memory_rw_entires[0].start_eid,
+            entry.memory_rw_entries[0].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[0].end_eid,
+            entry.memory_rw_entries[0].end_eid,
             step.current.sp + 1,
             LocationType::Stack,
             var_type == VarType::I32,
@@ -565,9 +565,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinConfig<F> {
 
         self.memory_table_lookup_stack_read_lhs.assign(
             ctx,
-            entry.memory_rw_entires[1].start_eid,
+            entry.memory_rw_entries[1].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[1].end_eid,
+            entry.memory_rw_entries[1].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             var_type == VarType::I32,
@@ -577,7 +577,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinConfig<F> {
         self.memory_table_lookup_stack_write.assign(
             ctx,
             step.current.eid,
-            entry.memory_rw_entires[2].end_eid,
+            entry.memory_rw_entries[2].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             var_type == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_bin_bit.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_bin_bit.rs
@@ -173,9 +173,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinBitConfig<F> {
 
         self.memory_table_lookup_stack_read_rhs.assign(
             ctx,
-            entry.memory_rw_entires[0].start_eid,
+            entry.memory_rw_entries[0].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[0].end_eid,
+            entry.memory_rw_entries[0].end_eid,
             step.current.sp + 1,
             LocationType::Stack,
             vtype == VarType::I32,
@@ -184,9 +184,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinBitConfig<F> {
 
         self.memory_table_lookup_stack_read_lhs.assign(
             ctx,
-            entry.memory_rw_entires[1].start_eid,
+            entry.memory_rw_entries[1].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[1].end_eid,
+            entry.memory_rw_entries[1].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             vtype == VarType::I32,
@@ -196,7 +196,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinBitConfig<F> {
         self.memory_table_lookup_stack_write.assign(
             ctx,
             step.current.eid,
-            entry.memory_rw_entires[2].end_eid,
+            entry.memory_rw_entries[2].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_bin_shift.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_bin_shift.rs
@@ -481,9 +481,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinShiftConfig<F> {
 
         self.memory_table_lookup_stack_read_rhs.assign(
             ctx,
-            entry.memory_rw_entires[0].start_eid,
+            entry.memory_rw_entries[0].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[0].end_eid,
+            entry.memory_rw_entries[0].end_eid,
             step.current.sp + 1,
             LocationType::Stack,
             !is_eight_bytes,
@@ -492,9 +492,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinShiftConfig<F> {
 
         self.memory_table_lookup_stack_read_lhs.assign(
             ctx,
-            entry.memory_rw_entires[1].start_eid,
+            entry.memory_rw_entries[1].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[1].end_eid,
+            entry.memory_rw_entries[1].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             !is_eight_bytes,
@@ -504,7 +504,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BinShiftConfig<F> {
         self.memory_table_lookup_stack_write.assign(
             ctx,
             step.current.eid,
-            entry.memory_rw_entires[2].end_eid,
+            entry.memory_rw_entries[2].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             !is_eight_bytes,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_br.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_br.rs
@@ -114,9 +114,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrConfig<F> {
 
                     self.memory_table_lookup_stack_read.assign(
                         ctx,
-                        entry.memory_rw_entires[0].start_eid,
+                        entry.memory_rw_entries[0].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[0].end_eid,
+                        entry.memory_rw_entries[0].end_eid,
                         step.current.sp + 1,
                         LocationType::Stack,
                         VarType::from(keep[0]) == VarType::I32,
@@ -126,7 +126,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrConfig<F> {
                     self.memory_table_lookup_stack_write.assign(
                         ctx,
                         step.current.eid,
-                        entry.memory_rw_entires[1].end_eid,
+                        entry.memory_rw_entries[1].end_eid,
                         step.current.sp + *drop + 1,
                         LocationType::Stack,
                         VarType::from(keep[0]) == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_br_if.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_br_if.rs
@@ -157,9 +157,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrIfConfig<F> {
 
                 self.memory_table_lookup_stack_read_cond.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,
@@ -177,9 +177,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrIfConfig<F> {
                     if *condition != 0 {
                         self.memory_table_lookup_stack_read_return_value.assign(
                             ctx,
-                            entry.memory_rw_entires[1].start_eid,
+                            entry.memory_rw_entries[1].start_eid,
                             step.current.eid,
-                            entry.memory_rw_entires[1].end_eid,
+                            entry.memory_rw_entries[1].end_eid,
                             step.current.sp + 2,
                             LocationType::Stack,
                             VarType::from(keep[0]) == VarType::I32,
@@ -189,7 +189,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrIfConfig<F> {
                         self.memory_table_lookup_stack_write_return_value.assign(
                             ctx,
                             step.current.eid,
-                            entry.memory_rw_entires[2].end_eid,
+                            entry.memory_rw_entries[2].end_eid,
                             step.current.sp + *drop + 2,
                             LocationType::Stack,
                             VarType::from(keep[0]) == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_br_if_eqz.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_br_if_eqz.rs
@@ -153,9 +153,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrIfEqzConfig<F> {
 
                 self.memory_table_lookup_stack_read_cond.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,
@@ -172,9 +172,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrIfEqzConfig<F> {
                     if *condition == 0 {
                         self.memory_table_lookup_stack_read_return_value.assign(
                             ctx,
-                            entry.memory_rw_entires[1].start_eid,
+                            entry.memory_rw_entries[1].start_eid,
                             step.current.eid,
-                            entry.memory_rw_entires[1].end_eid,
+                            entry.memory_rw_entries[1].end_eid,
                             step.current.sp + 2,
                             LocationType::Stack,
                             VarType::from(keep[0]) == VarType::I32,
@@ -184,7 +184,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrIfEqzConfig<F> {
                         self.memory_table_lookup_stack_write_return_value.assign(
                             ctx,
                             step.current.eid,
-                            entry.memory_rw_entires[2].end_eid,
+                            entry.memory_rw_entries[2].end_eid,
                             step.current.sp + *drop + 2,
                             LocationType::Stack,
                             VarType::from(keep[0]) == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_br_table.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_br_table.rs
@@ -202,9 +202,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrTableConfig<F> {
 
                 self.memory_table_lookup_stack_read_index.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,
@@ -221,9 +221,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrTableConfig<F> {
 
                     self.memory_table_lookup_stack_read_return_value.assign(
                         ctx,
-                        entry.memory_rw_entires[1].start_eid,
+                        entry.memory_rw_entries[1].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[1].end_eid,
+                        entry.memory_rw_entries[1].end_eid,
                         step.current.sp + 2,
                         LocationType::Stack,
                         VarType::from(keep[0]) == VarType::I32,
@@ -233,7 +233,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for BrTableConfig<F> {
                     self.memory_table_lookup_stack_write_return_value.assign(
                         ctx,
                         step.current.eid,
-                        entry.memory_rw_entires[2].end_eid,
+                        entry.memory_rw_entries[2].end_eid,
                         step.current.sp + drop + 2,
                         LocationType::Stack,
                         VarType::from(keep[0]) == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_call_host_foreign_circuit.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_call_host_foreign_circuit.rs
@@ -138,9 +138,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ExternalCallHostCircuitConfig<F>
                     ExternalHostCallSignature::Argument => {
                         self.memory_table_lookup_stack_read.assign(
                             ctx,
-                            entry.memory_rw_entires[0].start_eid,
+                            entry.memory_rw_entries[0].start_eid,
                             step.current.eid,
-                            entry.memory_rw_entires[0].end_eid,
+                            entry.memory_rw_entries[0].end_eid,
                             step.current.sp + 1,
                             LocationType::Stack,
                             false,
@@ -151,7 +151,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ExternalCallHostCircuitConfig<F>
                         self.memory_table_lookup_stack_write.assign(
                             ctx,
                             step.current.eid,
-                            entry.memory_rw_entires[0].end_eid,
+                            entry.memory_rw_entries[0].end_eid,
                             step.current.sp,
                             LocationType::Stack,
                             false,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_call_indirect.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_call_indirect.rs
@@ -153,9 +153,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for CallIndirectConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_const.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_const.rs
@@ -83,7 +83,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ConstConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp,
                     LocationType::Stack,
                     true,
@@ -98,7 +98,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ConstConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp,
                     LocationType::Stack,
                     false,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_conversion.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_conversion.rs
@@ -351,9 +351,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ConversionConfig<F> {
 
         self.memory_table_lookup_stack_read.assign(
             ctx,
-            entry.memory_rw_entires[0].start_eid,
+            entry.memory_rw_entries[0].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[0].end_eid,
+            entry.memory_rw_entries[0].end_eid,
             step.current.sp + 1,
             LocationType::Stack,
             value_type == VarType::I32,
@@ -363,7 +363,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ConversionConfig<F> {
         self.memory_table_lookup_stack_write.assign(
             ctx,
             step.current.eid,
-            entry.memory_rw_entires[1].end_eid,
+            entry.memory_rw_entries[1].end_eid,
             step.current.sp + 1,
             LocationType::Stack,
             result_type == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_global_get.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_global_get.rs
@@ -95,9 +95,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for GlobalGetConfig<F> {
 
                 self.memory_table_lookup_global_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     *idx,
                     LocationType::Global,
                     *vtype == VarType::I32,
@@ -107,7 +107,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for GlobalGetConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp,
                     LocationType::Stack,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_global_set.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_global_set.rs
@@ -95,9 +95,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for GlobalSetConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -107,7 +107,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for GlobalSetConfig<F> {
                 self.memory_table_lookup_global_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     *idx,
                     LocationType::Global,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_load.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_load.rs
@@ -540,9 +540,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LoadConfig<F> {
                 let mut i = 0;
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[i].start_eid,
+                    entry.memory_rw_entries[i].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[i].end_eid,
+                    entry.memory_rw_entries[i].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,
@@ -552,9 +552,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LoadConfig<F> {
 
                 self.memory_table_lookup_heap_read1.assign(
                     ctx,
-                    entry.memory_rw_entires[i].start_eid,
+                    entry.memory_rw_entries[i].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[i].end_eid,
+                    entry.memory_rw_entries[i].end_eid,
                     effective_address >> 3,
                     LocationType::Heap,
                     false,
@@ -565,9 +565,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LoadConfig<F> {
                 if is_cross_block {
                     self.memory_table_lookup_heap_read2.assign(
                         ctx,
-                        entry.memory_rw_entires[i].start_eid,
+                        entry.memory_rw_entries[i].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[i].end_eid,
+                        entry.memory_rw_entries[i].end_eid,
                         (effective_address >> 3) + 1,
                         LocationType::Heap,
                         false,
@@ -579,7 +579,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LoadConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[i].end_eid,
+                    entry.memory_rw_entries[i].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_local_get.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_local_get.rs
@@ -105,9 +105,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LocalGetConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + depth,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -117,7 +117,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LocalGetConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp,
                     LocationType::Stack,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_local_set.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_local_set.rs
@@ -105,9 +105,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LocalSetConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -117,7 +117,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LocalSetConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + 1 + depth,
                     LocationType::Stack,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_local_tee.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_local_tee.rs
@@ -105,9 +105,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LocalTeeConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -117,7 +117,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for LocalTeeConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + depth,
                     LocationType::Stack,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_memory_grow.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_memory_grow.rs
@@ -142,9 +142,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for MemoryGrowConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,
@@ -154,7 +154,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for MemoryGrowConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_memory_size.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_memory_size.rs
@@ -72,7 +72,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for MemorySizeConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp,
                     LocationType::Stack,
                     true,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_rel.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_rel.rs
@@ -458,9 +458,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for RelConfig<F> {
 
         self.memory_table_lookup_stack_read_rhs.assign(
             ctx,
-            entry.memory_rw_entires[0].start_eid,
+            entry.memory_rw_entries[0].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[0].end_eid,
+            entry.memory_rw_entries[0].end_eid,
             step.current.sp + 1,
             LocationType::Stack,
             var_type == VarType::I32,
@@ -469,9 +469,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for RelConfig<F> {
 
         self.memory_table_lookup_stack_read_lhs.assign(
             ctx,
-            entry.memory_rw_entires[1].start_eid,
+            entry.memory_rw_entries[1].start_eid,
             step.current.eid,
-            entry.memory_rw_entires[1].end_eid,
+            entry.memory_rw_entries[1].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             var_type == VarType::I32,
@@ -481,7 +481,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for RelConfig<F> {
         self.memory_table_lookup_stack_write.assign(
             ctx,
             step.current.eid,
-            entry.memory_rw_entires[2].end_eid,
+            entry.memory_rw_entries[2].end_eid,
             step.current.sp + 2,
             LocationType::Stack,
             true,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_return.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_return.rs
@@ -147,9 +147,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ReturnConfig<F> {
 
                     self.memory_table_lookup_stack_read.assign(
                         ctx,
-                        entry.memory_rw_entires[0].start_eid,
+                        entry.memory_rw_entries[0].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[0].end_eid,
+                        entry.memory_rw_entries[0].end_eid,
                         step.current.sp + 1,
                         LocationType::Stack,
                         VarType::from(keep[0]) == VarType::I32,
@@ -159,7 +159,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ReturnConfig<F> {
                     self.memory_table_lookup_stack_write.assign(
                         ctx,
                         step.current.eid,
-                        entry.memory_rw_entires[1].end_eid,
+                        entry.memory_rw_entries[1].end_eid,
                         step.current.sp + drop + 1,
                         LocationType::Stack,
                         VarType::from(keep[0]) == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_select.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_select.rs
@@ -165,9 +165,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for SelectConfig<F> {
 
                 self.memory_table_lookup_stack_read_cond.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,
@@ -176,9 +176,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for SelectConfig<F> {
 
                 self.memory_table_lookup_stack_read_val2.assign(
                     ctx,
-                    entry.memory_rw_entires[1].start_eid,
+                    entry.memory_rw_entries[1].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + 2,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -187,9 +187,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for SelectConfig<F> {
 
                 self.memory_table_lookup_stack_read_val1.assign(
                     ctx,
-                    entry.memory_rw_entires[2].start_eid,
+                    entry.memory_rw_entries[2].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[2].end_eid,
+                    entry.memory_rw_entries[2].end_eid,
                     step.current.sp + 3,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -199,7 +199,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for SelectConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[3].end_eid,
+                    entry.memory_rw_entries[3].end_eid,
                     step.current.sp + 3,
                     LocationType::Stack,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_store.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_store.rs
@@ -556,9 +556,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for StoreConfig<F> {
 
                 self.memory_table_lookup_stack_read_val.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     vtype == VarType::I32,
@@ -567,9 +567,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for StoreConfig<F> {
 
                 self.memory_table_lookup_stack_read_pos.assign(
                     ctx,
-                    entry.memory_rw_entires[1].start_eid,
+                    entry.memory_rw_entries[1].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + 2,
                     LocationType::Stack,
                     true,
@@ -578,9 +578,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for StoreConfig<F> {
 
                 self.memory_table_lookup_heap_read1.assign(
                     ctx,
-                    entry.memory_rw_entires[2].start_eid,
+                    entry.memory_rw_entries[2].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[2].end_eid,
+                    entry.memory_rw_entries[2].end_eid,
                     effective_address >> 3,
                     LocationType::Heap,
                     false,
@@ -590,7 +590,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for StoreConfig<F> {
                 self.memory_table_lookup_heap_write1.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[3].end_eid,
+                    entry.memory_rw_entries[3].end_eid,
                     effective_address >> 3,
                     LocationType::Heap,
                     false,
@@ -600,9 +600,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for StoreConfig<F> {
                 if is_cross_block {
                     self.memory_table_lookup_heap_read2.assign(
                         ctx,
-                        entry.memory_rw_entires[4].start_eid,
+                        entry.memory_rw_entries[4].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[4].end_eid,
+                        entry.memory_rw_entries[4].end_eid,
                         (effective_address >> 3) + 1,
                         LocationType::Heap,
                         false,
@@ -612,7 +612,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for StoreConfig<F> {
                     self.memory_table_lookup_heap_write2.assign(
                         ctx,
                         step.current.eid,
-                        entry.memory_rw_entires[5].end_eid,
+                        entry.memory_rw_entries[5].end_eid,
                         (effective_address >> 3) + 1,
                         LocationType::Heap,
                         false,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_test.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_test.rs
@@ -126,9 +126,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for TestConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -138,7 +138,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for TestConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,

--- a/crates/zkwasm/src/circuits/etable/op_configure/op_unary.rs
+++ b/crates/zkwasm/src/circuits/etable/op_configure/op_unary.rs
@@ -336,9 +336,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for UnaryConfig<F> {
 
                 self.memory_table_lookup_stack_read.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     *vtype == VarType::I32,
@@ -348,7 +348,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for UnaryConfig<F> {
                 self.memory_table_lookup_stack_write.assign(
                     ctx,
                     step.current.eid,
-                    entry.memory_rw_entires[1].end_eid,
+                    entry.memory_rw_entries[1].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     *vtype == VarType::I32,

--- a/crates/zkwasm/src/circuits/utils/table_entry.rs
+++ b/crates/zkwasm/src/circuits/utils/table_entry.rs
@@ -116,7 +116,7 @@ pub struct MemoryRWEntry {
 #[derive(Debug)]
 pub struct EventTableEntryWithMemoryInfo {
     pub eentry: EventTableEntry,
-    pub memory_rw_entires: Vec<MemoryRWEntry>,
+    pub memory_rw_entries: Vec<MemoryRWEntry>,
 }
 
 #[derive(Debug)]
@@ -161,7 +161,7 @@ impl EventTableWithMemoryInfo {
                 .iter()
                 .map(|eentry| EventTableEntryWithMemoryInfo {
                     eentry: eentry.clone(),
-                    memory_rw_entires: memory_event_of_step(eentry, &mut 1)
+                    memory_rw_entries: memory_event_of_step(eentry, &mut 1)
                         .iter()
                         .map(|mentry| {
                             let (start_eid, end_eid) = lookup_mtable_eid((

--- a/crates/zkwasm/src/foreign/context/etable_op_configure.rs
+++ b/crates/zkwasm/src/foreign/context/etable_op_configure.rs
@@ -176,7 +176,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ETableContextHelperTableConfig<F
                     self.lookup_write_stack.assign(
                         ctx,
                         step.current.eid,
-                        entry.memory_rw_entires[0].end_eid,
+                        entry.memory_rw_entries[0].end_eid,
                         step.current.sp,
                         LocationType::Stack,
                         false,
@@ -193,9 +193,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ETableContextHelperTableConfig<F
                     self.output_value.assign(ctx, F::from(value))?;
                     self.lookup_read_stack.assign(
                         ctx,
-                        entry.memory_rw_entires[0].start_eid,
+                        entry.memory_rw_entries[0].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[0].end_eid,
+                        entry.memory_rw_entries[0].end_eid,
                         step.current.sp + 1,
                         LocationType::Stack,
                         false,

--- a/crates/zkwasm/src/foreign/require_helper/etable_op_configure.rs
+++ b/crates/zkwasm/src/foreign/require_helper/etable_op_configure.rs
@@ -106,9 +106,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ETableRequireHelperTableConfig<F
                     .assign(ctx, F::from(cond).invert().unwrap_or(F::zero()))?;
                 self.memory_table_lookup_read_stack.assign(
                     ctx,
-                    entry.memory_rw_entires[0].start_eid,
+                    entry.memory_rw_entries[0].start_eid,
                     step.current.eid,
-                    entry.memory_rw_entires[0].end_eid,
+                    entry.memory_rw_entries[0].end_eid,
                     step.current.sp + 1,
                     LocationType::Stack,
                     true,

--- a/crates/zkwasm/src/foreign/wasm_input_helper/etable_op_configure.rs
+++ b/crates/zkwasm/src/foreign/wasm_input_helper/etable_op_configure.rs
@@ -213,9 +213,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ETableWasmInputHelperTableConfig
 
                     self.lookup_read_stack.assign(
                         ctx,
-                        entry.memory_rw_entires[0].start_eid,
+                        entry.memory_rw_entries[0].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[0].end_eid,
+                        entry.memory_rw_entries[0].end_eid,
                         step.current.sp + 1,
                         LocationType::Stack,
                         true,
@@ -225,7 +225,7 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ETableWasmInputHelperTableConfig
                     self.lookup_write_stack.assign(
                         ctx,
                         step.current.eid,
-                        entry.memory_rw_entires[1].end_eid,
+                        entry.memory_rw_entries[1].end_eid,
                         step.current.sp + 1,
                         LocationType::Stack,
                         false,
@@ -248,9 +248,9 @@ impl<F: FieldExt> EventTableOpcodeConfig<F> for ETableWasmInputHelperTableConfig
 
                     self.lookup_read_stack.assign(
                         ctx,
-                        entry.memory_rw_entires[0].start_eid,
+                        entry.memory_rw_entries[0].start_eid,
                         step.current.eid,
-                        entry.memory_rw_entires[0].end_eid,
+                        entry.memory_rw_entries[0].end_eid,
                         step.current.sp + 1,
                         LocationType::Stack,
                         false,


### PR DESCRIPTION
#### What does this PR do?
This Pull Request corrects the misspelling of the word "entries" throughout the codebase. Previously, it was incorrectly spelled as "entires".

#### Description of Task to be completed?
- Search for all instances of "entires" in the repository.
- Replace them with the correct spelling "entries".
- Ensure that the changes do not affect the functionality of the code.

#### How should this be manually tested?
1. Pull this branch to your local machine.
2. Search the repository to ensure every instance of "entires" has been replaced with "entries".
3. Run the usual tests to make sure that all functionalities are intact.

#### Any background context you want to provide?
The typo was found in various files across the repository, and it could potentially lead to confusion in understanding the code. Correcting this typo improves the readability and maintainability of the code.

#### Questions:
Any questions or concerns can be raised within this PR discussion.

#### Checklist:
- [x] I have searched for any additional instances of the typo.
- [x] I have run tests to ensure that my changes do not introduce any new issues or break existing features.
- [x] I have followed the contribution guidelines and coding standards of this project.

### Conclusion:
Please review the changes and merge this pull request if everything is in order. Let me know if there are any further adjustments I should make. Thank you!