### PR TITLE
typo fix Update mod.rs

### DIFF
--- a/crates/zkwasm/src/runtime/monitor/plugins/table/mod.rs
+++ b/crates/zkwasm/src/runtime/monitor/plugins/table/mod.rs
@@ -617,7 +617,7 @@ impl<B: SliceBackendBuilder> Monitor for TablePlugin<B> {
                 instruction,
             );
 
-            // Since we cannot get return value now, we store the incompete event
+            // Since we cannot get return value now, we store the incomplete event
             // and fix later.
             if matches!(step_info, StepInfo::CallHost { .. })
                 || matches!(step_info, StepInfo::ExternalHostCall { .. })


### PR DESCRIPTION
# Typo Fix in `mod.rs`

## Description
This pull request corrects a typo in the `mod.rs` file:
- Fixed "incompete" to "incomplete" in a code comment.

## Changes
- Enhanced readability and accuracy in the comments by fixing a minor spelling error.

## Testing
This change only affects a comment in the code and does not alter functionality. No additional testing is required.

## Notes for Reviewers
Please verify the typo correction to ensure it aligns with the project's style guidelines. If there are any further changes needed, feel free to provide feedback. Thank you!
