### PR TITLE
docs: fixed broken link to the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ We use z3 (https://github.com/Z3Prover/z3) to check that all operations are comp
 - C project: There is a project template for compiling C to wasm with limited host functions (foreign circuits). (see https://github.com/DelphinusLab/zkWasm-C)
 - Rust project demo: https://github.com/xgaozoyoe/zkWasm-Rust-Demo
 - Assembly script demo: https://github.com/DelphinusLab/zkWasm-AssemblyScript-Demo
-- Browser based project: See https://github.com/zkcrossteam/g1024/ for how to utilize zkWASM in javascript, how to generate proofs using PAAS service and verify it on chain (contact xgao@zoyoe.com for details about PAAS testnet).
+- Browser based project: See https://github.com/zkcrossteam/zk-2048 for how to utilize zkWASM in javascript, how to generate proofs using PAAS service and verify it on chain (contact xgao@zoyoe.com for details about PAAS testnet).


### PR DESCRIPTION
I noticed that the link to the repository was outdated, so I replaced it with the correct one.

Now the link points to the working repository at [[zk-2048](https://github.com/zkcrossteam/zk-2048)](https://github.com/zkcrossteam/zk-2048).