### PR TITLE
docs: fix typo in project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Overview：
 
-The mission of DelphiusLab is to provide Web2 developers with a concise toolset to leverage the power of Web3 in their applications. The ZKWASM (ZKSNARK virtual machine that supports Web Assembly) serves as a trustless layer between rich applications running on WASM runtime and smart contracts on chain.
+The mission of DelphinusLab is to provide Web2 developers with a concise toolset to leverage the power of Web3 in their applications. The ZKWASM (ZKSNARK virtual machine that supports Web Assembly) serves as a trustless layer between rich applications running on WASM runtime and smart contracts on chain.
 
 WASM (or WebAssembly) is an open standard binary code format similar to assembly. Its initial objective was to provide an alternative to java-script with improved performance for the current web ecosystem. Benefiting from its platform independence, front-end flexibility (can be compiled from the majority of languages including C, C++, assembly script, rust, etc.), good isolated runtime and speed comes closer to the speed of a native binary, its usage is arising in distributed cloud and edge computing. Recently it has become a popular binary format for users to run customized functions on AWS Lambda, Open Yurt, AZURE, etc.
 


### PR DESCRIPTION
<img width="923" alt="Снимок экрана 2025-04-23 в 11 17 50" src="https://github.com/user-attachments/assets/a5458ae6-adaf-4139-830c-ed86d4c71e36" />

corrected a typo in the project name.

was previously written as "DelphiusLab" but should be "**DelphinusLab**". 