### PR TITLE
fix: remove unused HostOpSelector import from keccak256.rs

### DIFF
--- a/crates/host/src/host/hash_helper/keccak256.rs
+++ b/crates/host/src/host/hash_helper/keccak256.rs
@@ -2,7 +2,6 @@ use delphinus_zkwasm::runtime::host::host_env::HostEnv;
 use delphinus_zkwasm::runtime::host::ForeignContext;
 use delphinus_zkwasm::runtime::host::ForeignStatics;
 use std::rc::Rc;
-use zkwasm_host_circuits::circuits::host::HostOpSelector;
 use zkwasm_host_circuits::circuits::keccak256::KeccakChip;
 use zkwasm_host_circuits::host::keccak256::Keccak;
 use zkwasm_host_circuits::host::ForeignInst::Keccak256Finalize;


### PR DESCRIPTION
Remove unused HostOpSelector import that was imported but never used in the keccak256 module. This cleans up the code and reduces compilation overhead.